### PR TITLE
Fix flash message handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -55,9 +55,7 @@ app.get("/", async (request, response, next) => {
         response.render("index", {
             posts,
             page,
-            totalPages,
-            success: request.flash("success"),
-            error: request.flash("error")
+            totalPages
         })
     } catch (error) {
         next(error);
@@ -130,7 +128,7 @@ app.post("/login", [
   const errors = validationResult(request);
   if (!errors.isEmpty()){
     request.flash("error", errors.array().map(e => e.msg).join(", "));
-    response.redirect("/login");
+    return response.redirect("/login");
   }
   try {
     const user = await prisma.user.findUnique({where : {email : request.body.email}});
@@ -165,7 +163,7 @@ app.post("/posts/:id/delete", async (request, response, next) => {
     );
     if (!post || post.authorId !== request.session.userId){
       request.flash("error", "削除できません。");
-      return reponse.redirect("/");
+      return response.redirect("/");
     }
     await prisma.post.delete({
       where : { id : Number(request.params.id)}

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -25,8 +25,8 @@
            x-init="setTimeout(() => show = false, 3000)"
            x-show="show"
            class="mb-4 p-4 rounded shadow"
-           :class="{'bg-green-100 text-green-800': `<%= success %>`, 'bg-red-100 text-red-800': `<%= error %>`}">
-        <p x-text="`<%= success ? success : error %>`"></p>
+           :class="{'bg-green-100 text-green-800': `<%= flash.success %>`, 'bg-red-100 text-red-800': `<%= flash.error %>`}">
+        <p x-text="`<%= flash.success ? flash.success : flash.error %>`"></p>
       </div>
     </template>
 

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -9,7 +9,7 @@
   <div class="bg-white p-8 rounded shadow w-full max-w-md">
     <h1 class="text-2xl font-bold mb-6 text-center">ログイン</h1>
 
-    <% if (flash && flash.error) { %>
+    <% if (flash.error && flash.error.length) { %>
       <div class="bg-red-100 text-red-700 p-3 rounded mb-4 text-center">
         <%= flash.error %>
       </div>

--- a/views/register.ejs
+++ b/views/register.ejs
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="/styles.css">
 </head>
 <body>
-  <% if (flash.error) { %>
+  <% if (flash.error && flash.error.length) { %>
     <p class="text-red-500"><%= flash.error %></p>
   <% } %>
   <form action="/register" method="post" class="space-y-4">


### PR DESCRIPTION
## Summary
- fix login validation early return
- fix unauthorized delete redirect bug
- remove double flash consumption for index page
- reference flash messages correctly in views

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6860e8672e2c83209a83ab4cd9dad15f